### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ DCKit is a set of *@IBDesignable* iOS controls (`UIButtons`, `UITextFields` etc.
 
 Written on Swift.
 
-##Preview
+## Preview
 
 [![DCKit preview](Images/screenshot_001.png)](Images/screenshot_001.png)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
